### PR TITLE
Make PL/Julia work with PostgreSQL 15.

### DIFF
--- a/pljulia.c
+++ b/pljulia.c
@@ -746,14 +746,6 @@ _PG_init(void)
 	pljulia_query_hashtable = hash_create("PL/Julia cached plans hashtable",
 										  32, &hash_ctl, HASH_ELEM);
 
-	/*
-	 * Our global data, a dictionary named GD, which holds data we want to be
-	 * shared between functions. This is also used for saved query plans. It's
-	 * initialized to an empty dictionary. This dictionary is a global
-	 * variable for the main module
-	 */
-	GD = jl_eval_string("GD = Dict()");
-
 	char	   *dict_set_command,
 			   *dict_get_command;
 
@@ -2119,7 +2111,13 @@ pljulia_validator(PG_FUNCTION_ARGS)
 	{
 		if (proc->prorettype == TRIGGEROID)
 			is_trigger = true;
-		else if (proc->prorettype == EVTTRIGGEROID)
+		else if (proc->prorettype ==
+#if PG_VERSION_NUM >= 140000
+			 EVENT_TRIGGEROID
+#else
+			 EVTTRIGGEROID
+#endif
+			 )
 			is_event_trigger = true;
 		else if (proc->prorettype != RECORDOID &&
 				 proc->prorettype != VOIDOID)


### PR DESCRIPTION
This patch makes PL/Julia work with PostgreSQL 15. Also, this patch removes a duplicate initialization of global dict 'GD' (See line 745 of file 'pljulia.c').
The regression tests w/ PostgreSQL 15 are passed.

We should reference 'EVENT_TRIGGEROID' when building PL/Julia w/ PostgreSQL >= 14.
See: https://github.com/postgres/postgres/commit/f90149e6285aaae6b48559afce1bd638ee26c33e