### PR TITLE
Fix buffer overflow when loading Julia packages with long names

### DIFF
--- a/pljulia.c
+++ b/pljulia.c
@@ -29,6 +29,7 @@
 #include <utils/guc.h>
 #include "parser/parse_type.h"
 
+#include <limits.h>
 #include <sys/time.h>
 #include <julia.h>
 #include "convert_args.h"
@@ -795,16 +796,11 @@ _PG_init(void)
 	npackages = jl_array_len(packages);
 	for (i = 0; i < npackages; i++)
 	{
-		char		packname[256];
+		char		packname[NAME_MAX + 7];	/* "using "(6) + name(255) + '\0'(1) */
 		jl_value_t *package;
-		int			j;
 
-		packname[0] = '\0';
 		package = jl_array_ptr_ref(packages, i);
-		strcpy(packname, "using ");
-		strcat(packname, jl_string_ptr(package));
-		j = strlen(packname);
-		packname[j] = '\0';
+		snprintf(packname, sizeof(packname), "using %s", jl_string_ptr(package));
 		jl_eval_string(packname);
 	}
 	JL_GC_POP();


### PR DESCRIPTION
**What type of PR is this?**  

Potential bug fix  

Makes package loading safer and prevents a possible buffer overflow.  

**What this PR does / why we need it:**  

- Fixes a potential buffer overflow in packname by replacing strcpy / strcat (which do not perform bounds checking) with snprintf, ensuring writes stay within sizeof(packname).

- Sizes the buffer correctly as `NAME_MAX + 7`:                        
"using " + NAME_MAX + '\0'

- Removes unnecessary variables such as `j`

**Which issue(s) this PR fixes:**  

Fixes a potential buffer overflow when loading Julia packages with long names.  