### PR TITLE
Add SD (per-function session dictionary)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,12 +23,13 @@ PG_CFLAGS += $(shell $(JULIA) $(JL_SHARE)/julia-config.jl --cflags)
 PG_CPPFLAGS += $(shell $(JULIA) $(JL_SHARE)/julia-config.jl --cflags)
 PG_LDFLAGS += $(shell $(JULIA) $(JL_SHARE)/julia-config.jl --ldflags)
 PG_LDFLAGS += $(shell $(JULIA) $(JL_SHARE)/julia-config.jl --ldlibs)
+override CFLAGS_SL_MODULE =
 
 REGRESS = create return_bigint return_char return_decimal \
 		return_double_precision return_integer return_numeric return_real \
 		return_smallint return_text return_varchar in_array_integer in_array_float \
 		in_array_string in_composite return_array return_composite return_set \
-		trigger_test event_trigger do_block exec_query shared plan
+		trigger_test event_trigger do_block exec_query shared plan sd
 
 ifdef USE_PGXS
 PG_CONFIG = pg_config

--- a/expected/sd.out
+++ b/expected/sd.out
@@ -1,0 +1,96 @@
+-- Test SD: per-function private dictionary
+-- Test 1: basic persistence across calls
+CREATE FUNCTION sd_counter() RETURNS int AS $$
+    if !haskey(SD, "n")
+        SD["n"] = 0
+    end
+    SD["n"] += 1
+    return SD["n"]
+$$ LANGUAGE pljulia;
+SELECT sd_counter();
+ sd_counter 
+------------
+          1
+(1 row)
+
+SELECT sd_counter();
+ sd_counter 
+------------
+          2
+(1 row)
+
+SELECT sd_counter();
+ sd_counter 
+------------
+          3
+(1 row)
+
+-- Test 2: SD is private — two functions do not share state
+CREATE FUNCTION sd_func_a() RETURNS text AS $$
+    if !haskey(SD, "who")
+        SD["who"] = "set by func_a"
+    end
+    return SD["who"]
+$$ LANGUAGE pljulia;
+CREATE FUNCTION sd_func_b() RETURNS text AS $$
+    if !haskey(SD, "who")
+        SD["who"] = "set by func_b"
+    end
+    return SD["who"]
+$$ LANGUAGE pljulia;
+SELECT sd_func_a();
+   sd_func_a   
+---------------
+ set by func_a
+(1 row)
+
+SELECT sd_func_b();
+   sd_func_b   
+---------------
+ set by func_b
+(1 row)
+
+SELECT sd_func_a();
+   sd_func_a   
+---------------
+ set by func_a
+(1 row)
+
+-- Test 3: SD resets after CREATE OR REPLACE
+CREATE FUNCTION sd_reset_test() RETURNS int AS $$
+    if !haskey(SD, "n")
+        SD["n"] = 0
+    end
+    SD["n"] += 1
+    return SD["n"]
+$$ LANGUAGE pljulia;
+SELECT sd_reset_test();
+ sd_reset_test 
+---------------
+             1
+(1 row)
+
+SELECT sd_reset_test();
+ sd_reset_test 
+---------------
+             2
+(1 row)
+
+CREATE OR REPLACE FUNCTION sd_reset_test() RETURNS int AS $$
+    if !haskey(SD, "n")
+        SD["n"] = 0
+    end
+    SD["n"] += 1
+    return SD["n"]
+$$ LANGUAGE pljulia;
+SELECT sd_reset_test();
+ sd_reset_test 
+---------------
+             1
+(1 row)
+
+-- Cleanup
+DROP FUNCTION sd_counter();
+DROP FUNCTION sd_func_a();
+DROP FUNCTION sd_func_b();
+DROP FUNCTION sd_reset_test();

--- a/pljulia.c
+++ b/pljulia.c
@@ -67,6 +67,7 @@ typedef struct pljulia_proc_desc
 	bool	   *arg_is_rowtype; /* is the argument composite? */
 	bool		fn_retisset;	/* true if function returns set (SRF) */
 	bool		fn_retistuple;	/* true if function returns composite */
+	char       *sd_varname;
 } pljulia_proc_desc;
 
 /* the information we cache about prepared and saved plans */
@@ -1418,6 +1419,13 @@ pljulia_compile(FunctionCallInfo fcinfo, HeapTuple procedure_tuple,
 		prodesc->arg_out_func = (FmgrInfo *) palloc0(prodesc->nargs *
 													 sizeof(FmgrInfo));
 		prodesc->arg_arraytype = (Oid *) palloc0(prodesc->nargs * sizeof(Oid));
+		
+		char sd_cmd[64]; char sd_var[64];
+		snprintf(sd_var, sizeof(sd_var), "pljulia_sd_%u", (unsigned)proc_key.fn_oid);
+		snprintf(sd_cmd, sizeof(sd_cmd), "%s = Dict()", sd_var);
+		jl_eval_string(sd_cmd);
+		prodesc->sd_varname = pstrdup(sd_var);
+	
 		prodesc->arg_is_rowtype = (bool *) palloc0(prodesc->nargs * sizeof(bool));
 		MemoryContextSwitchTo(oldcontext);
 	}
@@ -1465,6 +1473,13 @@ pljulia_compile(FunctionCallInfo fcinfo, HeapTuple procedure_tuple,
 		prodesc->user_proname = pstrdup(NameStr(procedure_struct->proname));
 		prodesc->internal_proname = pstrdup(internal_procname);
 		prodesc->mcxt = proc_cxt;
+	
+		char sd_cmd[64]; char sd_var[64];
+		snprintf(sd_var, sizeof(sd_var), "pljulia_sd_%u", (unsigned)proc_key.fn_oid);
+		snprintf(sd_cmd, sizeof(sd_cmd), "%s = Dict()", sd_var);
+		jl_eval_string(sd_cmd);
+		prodesc->sd_varname = pstrdup(sd_var);
+	
 		MemoryContextSwitchTo(oldcontext);
 	}
 	else if (is_event_trigger)
@@ -1509,6 +1524,12 @@ pljulia_compile(FunctionCallInfo fcinfo, HeapTuple procedure_tuple,
 		prodesc->user_proname = pstrdup(NameStr(procedure_struct->proname));
 		prodesc->internal_proname = pstrdup(internal_procname);
 		prodesc->mcxt = proc_cxt;
+
+		char sd_cmd[64]; char sd_var[64];
+		snprintf(sd_var, sizeof(sd_var), "pljulia_sd_%u", (unsigned)proc_key.fn_oid);
+		snprintf(sd_cmd, sizeof(sd_cmd), "%s = Dict()", sd_var);
+		jl_eval_string(sd_cmd);
+		prodesc->sd_varname = pstrdup(sd_var);
 		MemoryContextSwitchTo(oldcontext);
 	}
 	/* Create a new hashtable entry for the new function definition */
@@ -1577,6 +1598,11 @@ pljulia_execute(FunctionCallInfo fcinfo)
 						   boxed_args, prodesc);
 	if (jl_exception_occurred())
 		show_julia_error();
+
+	char sd_assign[80];
+	snprintf(sd_assign, sizeof(sd_assign), "SD = %s", prodesc->sd_varname);
+	jl_eval_string(sd_assign);
+
 	ret = jl_call(func, boxed_args, prodesc->nargs);
 
 	if (jl_exception_occurred())
@@ -1967,6 +1993,10 @@ pljulia_trigger_handler(PG_FUNCTION_ARGS)
 	/* Now call the trigger function */
 	func = jl_get_function(jl_main_module, prodesc->internal_proname);
 
+	char sd_assign[80];
+	snprintf(sd_assign, sizeof(sd_assign), "SD = %s", prodesc->sd_varname);
+	jl_eval_string(sd_assign);
+
 	ret = jl_call(func, trig_args, 10);
 	if (jl_exception_occurred())
 		show_julia_error();
@@ -2057,6 +2087,9 @@ pljulia_event_trigger_handler(PG_FUNCTION_ARGS)
 
 	func = jl_get_function(jl_main_module, prodesc->internal_proname);
 	/* the value returned by an event trigger is ignored */
+	char sd_assign[80];
+	snprintf(sd_assign, sizeof(sd_assign), "SD = %s", prodesc->sd_varname);
+	jl_eval_string(sd_assign);
 	jl_call2(func, trig_args[0], trig_args[1]);
 	if (jl_exception_occurred())
 		show_julia_error();

--- a/sql/sd.sql
+++ b/sql/sd.sql
@@ -1,0 +1,61 @@
+-- Test SD: per-function private dictionary
+
+-- Test 1: basic persistence across calls
+CREATE FUNCTION sd_counter() RETURNS int AS $$
+    if !haskey(SD, "n")
+        SD["n"] = 0
+    end
+    SD["n"] += 1
+    return SD["n"]
+$$ LANGUAGE pljulia;
+
+SELECT sd_counter();
+SELECT sd_counter();
+SELECT sd_counter();
+
+-- Test 2: SD is private — two functions do not share state
+CREATE FUNCTION sd_func_a() RETURNS text AS $$
+    if !haskey(SD, "who")
+        SD["who"] = "set by func_a"
+    end
+    return SD["who"]
+$$ LANGUAGE pljulia;
+
+CREATE FUNCTION sd_func_b() RETURNS text AS $$
+    if !haskey(SD, "who")
+        SD["who"] = "set by func_b"
+    end
+    return SD["who"]
+$$ LANGUAGE pljulia;
+
+SELECT sd_func_a();
+SELECT sd_func_b();
+SELECT sd_func_a();
+
+-- Test 3: SD resets after CREATE OR REPLACE
+CREATE FUNCTION sd_reset_test() RETURNS int AS $$
+    if !haskey(SD, "n")
+        SD["n"] = 0
+    end
+    SD["n"] += 1
+    return SD["n"]
+$$ LANGUAGE pljulia;
+
+SELECT sd_reset_test();
+SELECT sd_reset_test();
+
+CREATE OR REPLACE FUNCTION sd_reset_test() RETURNS int AS $$
+    if !haskey(SD, "n")
+        SD["n"] = 0
+    end
+    SD["n"] += 1
+    return SD["n"]
+$$ LANGUAGE pljulia;
+
+SELECT sd_reset_test();
+
+-- Cleanup
+DROP FUNCTION sd_counter();
+DROP FUNCTION sd_func_a();
+DROP FUNCTION sd_func_b();
+DROP FUNCTION sd_reset_test();


### PR DESCRIPTION
## Fix #27

###  Changes
- Introduce `SD`, a built-in per-function dictionary available inside every PL/Julia function.

- At compile time:
  - Create a `Dict()` in Julia runtime memory (heap).
  - Assign it a unique name derived from the function OID.
  - Store this name in `pljulia_proc_desc`.

- At execution time:
  - Assign `SD` to the corresponding dictionary before invoking the function.

- Design decisions:
  - Store the name instead of a pointer to avoid Julia GC collecting the object.
  - Use `Dict` to allow arbitrary key/value storage and match behavior of other PLs.

### Usage example (to be documented)
Users can now use `SD` inside PL/Julia functions to store per-function persistent state.
```sql
CREATE FUNCTION sd_counter() RETURNS int AS $$
    if !haskey(SD, "n")
        SD["n"] = 0
    end
    SD["n"] += 1
    return SD["n"]
$$ LANGUAGE pljulia;

SELECT sd_counter(); -- 1
SELECT sd_counter(); -- 2
SELECT sd_counter(); -- 3
```
### Tests
- Added `sql/sd.sql` and `expected/sd.out`
- Covers:
   - persistence across calls
   - isolation between functions
   - reset behavior on replace